### PR TITLE
Fix actions/cache ::set-output deprecated

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
GitHub Actions log messages: "*The `set-output` command is deprecated and
    will be disabled soon. Please upgrade to using Environment Files.*"

* More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* And on the official `actions/cache@3` documentation page where an example is given: https://github.com/actions/cache/blob/main/examples.md#php---composer

And 3 weeks ago, an issue was posted on GitHub's actions/cache https://github.com/actions/cache/issues/1142 mentioning the warning from the GitHub Actions' logs.